### PR TITLE
GradientEverything: fix blank lines being generated

### DIFF
--- a/modules/LibLyger.moon
+++ b/modules/LibLyger.moon
@@ -299,6 +299,7 @@ class LibLyger
             temp_tag = val.tag
             -- Cycle through all the tag blocks and interpolate
             for ctag, param in pairs start_state_table[k]
+                temp_tag = "{}" if #temp_tag == 0
                 temp_tag = temp_tag\gsub "}", ->
                     tval_start, tval_end = start_state_table[k][ctag], end_state_table[k][ctag]
                     tag_type = LibLyger.param_type[ctag]


### PR DESCRIPTION
This fixes a regression that would cause blank lines to be generated when no tags in addition to those having a gradient applied are present in the first tag section of a line. 

Currently includes a function that will later be moved into the _ASSFoundation.Common_ module. The new _Common_ release isn't quite ready yet and i don't want it blocking this fix.

Fixes #8.
